### PR TITLE
Fix unit test that caused CRAN check to fail

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: matchingR
 Type: Package
 Title: Matching Algorithms in R and C++
 Version: 1.3.3
-Date: 2021-05-22
+Date: 2021-05-25
 Author: Jan Tilly, Nick Janetos
 Maintainer: Jan Tilly <jantilly@gmail.com>
 Description: Computes matching algorithms quickly using Rcpp.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: matchingR
 Type: Package
 Title: Matching Algorithms in R and C++
 Version: 1.3.3
-Date: 2020-12-14
+Date: 2021-05-22
 Author: Jan Tilly, Nick Janetos
 Maintainer: Jan Tilly <jantilly@gmail.com>
 Description: Computes matching algorithms quickly using Rcpp.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: matchingR
 Type: Package
 Title: Matching Algorithms in R and C++
-Version: 1.3.2
+Version: 1.3.3
 Date: 2020-12-14
 Author: Jan Tilly, Nick Janetos
 Maintainer: Jan Tilly <jantilly@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# matchingR 1.3.3
+
+ * Fixed unit test for validate functions that caused a CRAN check to fail.
+
 # matchingR 1.3.2
 
  * Fix vignette index.

--- a/tests/testthat/test_galeshapley.R
+++ b/tests/testthat/test_galeshapley.R
@@ -79,7 +79,7 @@ test_that("Check if incorrect preference orders result in an error", {
   )
 })
 
-test_that("Check if validate function", {
+test_that("Check validate function", {
   # generate cardinal and ordinal preferences
   uM <- matrix(runif(12), nrow = 4, ncol = 3)
   uW <- matrix(runif(12), nrow = 4, ncol = 3)
@@ -91,7 +91,7 @@ test_that("Check if validate function", {
   expect_error(galeShapley.validate(proposerPref = prefM, reviewerPref = prefW))
 
   # generate cardinal and ordinal preferences
-  uM <- matrix(runif(12), nrow = 4, ncol = 4)
+  uM <- matrix(runif(16), nrow = 4, ncol = 4)
   uW <- matrix(runif(12), nrow = 4, ncol = 3)
   prefM <- sortIndex(uM)
   prefW <- sortIndex(uW)


### PR DESCRIPTION
For the test it didn't matter that we recycled the inputs, but CRAN appears to mind that we don't know basic arithmetic. 