### PR TITLE
Prepare release

### DIFF
--- a/.github/workflows/pr-commands.yaml
+++ b/.github/workflows/pr-commands.yaml
@@ -41,48 +41,8 @@ jobs:
         run: |
           git config --local user.name "$GITHUB_ACTOR"
           git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
-          git add man/\* NAMESPACE
+          git add man/\* NAMESPACE R/*.R src/*.cpp
           git commit -m 'Document'
-
-      - uses: r-lib/actions/pr-push@v2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-
-  compile:
-    if: ${{ github.event.issue.pull_request && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER') && startsWith(github.event.comment.body, '/compile') }}
-    name: compile
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: r-lib/actions/pr-fetch@v2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: any::Rcpp
-          needs: pr-compile
-
-      - name: Compile
-        run: Rcpp::compileAttributes()
-        shell: Rscript {0}
-
-      - name: commit
-        run: |
-          git config --local user.name "$GITHUB_ACTOR"
-          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
-          git add man/\* NAMESPACE
-          git commit -m 'Compile attributes'
 
       - uses: r-lib/actions/pr-push@v2
         with:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# matchingR 2.0.0
+
+- Remove deprecated functions.
+- Drop `CXX11` standard.
+
 # matchingR 1.3.3
 
 - Fixed unit test for validate functions that caused a CRAN check to fail.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Matching Algorithms in R and C++
 
 [![GitHub Actions](https://github.com/jtilly/matchingR/workflows/Test%20Package/badge.svg)](https://github.com/jtilly/matchingR/actions)
-[![Coverage Status](https://coveralls.io/repos/jtilly/matchingR/badge.svg?branch=master)](https://coveralls.io/github/jtilly/matchingR)
+[![Coverage Status](https://coveralls.io/repos/jtilly/matchingR/badge.svg?branch=main)](https://coveralls.io/github/jtilly/matchingR)
 [![CRAN_Status_Badge](https://www.r-pkg.org/badges/version/matchingR)](https://cran.r-project.org/package=matchingR)
 [![CRAN_Downloads](https://cranlogs.r-pkg.org/badges/grand-total/matchingR?color=brightgreen)](https://cran.r-project.org/package=matchingR)
 


### PR DESCRIPTION
CRAN writes

```
Dear maintainer,

Please see the problems shown on
<https://cran.r-project.org/web/checks/check_results_matchingR.html>.

Specifically, please see the NOTE about

  Specified C++11: please drop specification unless essential

from the C++ specification check. 

Asking for exactly C++11 when the current R default is C++17 is
generally no longer appropriate, and specifically causes problems when
having {RcppArmadillo} in LinkingTo (as you do): Armadillo 15 requires
at least C++14 and hence {RcppArmadillo} should do so too.  For now,
Dirk has added transition code which falls back to using older versions
of Armadillo when C++11 is asked for, but this will be changed soon, in
which case your package will no longer compile and install.

Quite likely the only change necessary on your end is to simply stop
requiring exactly C++11.  Can you please do so as soon as possible?

```